### PR TITLE
Update contact.html to align contact details icons

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -148,12 +148,12 @@
                 <p>
                     3481 Melrose Place<br>Beverly Hills, CA 90210<br>
                 </p>
-                <p><i class="fa fa-phone"></i> 
+                <p><i class="fa fa-phone fa-fw"></i> 
                     <abbr title="Phone">P</abbr>: (123) 456-7890</p>
-                <p><i class="fa fa-envelope-o"></i> 
+                <p><i class="fa fa-envelope-o fa-fw"></i> 
                     <abbr title="Email">E</abbr>: <a href="mailto:name@example.com">name@example.com</a>
                 </p>
-                <p><i class="fa fa-clock-o"></i> 
+                <p><i class="fa fa-clock-o fa-fw"></i> 
                     <abbr title="Hours">H</abbr>: Monday - Friday: 9:00 AM to 5:00 PM</p>
                 <ul class="list-unstyled list-inline list-social-icons">
                     <li>


### PR DESCRIPTION
The Font Awesome icons for "phone", "email" and "hours" aren't all the exact same width, so the text following each icon subsequently doesn't align across the three lines. Adding Font Awesome's `fa-fw` class to the icons makes them fixed-width and removes the misalignment.
The `fa-fw` class has been part of Font Awesome since at least v. 4.0.1 from late 2013.